### PR TITLE
Forward to the ORT documentation page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <meta http-equiv="refresh" content="0;URL='https://github.com/oss-review-toolkit/ort'" />
+        <meta http-equiv="refresh" content="0;URL='https://oss-review-toolkit.org/ort'" />
     </head>
 </html>


### PR DESCRIPTION
Forward to the ORT documentation instead of the GitHub project.